### PR TITLE
Add support for cancel by client order id

### DIFF
--- a/xchange-kucoin/pom.xml
+++ b/xchange-kucoin/pom.xml
@@ -9,7 +9,7 @@
 	</parent>
 
 	<properties>
-		<project.version>CHRONOS-5.4.0</project.version>
+		<project.version>CHRONOS-5.4.0-local</project.version>
 	</properties>
 
 	<groupId>io.github.chronos-labs</groupId>
@@ -48,7 +48,7 @@
 		<dependency>
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>
-			<version>1.18.22</version>
+			<version>1.18.30</version>
 			<scope>compile</scope>
 		</dependency>
 	</dependencies>

--- a/xchange-kucoin/pom.xml
+++ b/xchange-kucoin/pom.xml
@@ -9,7 +9,7 @@
 	</parent>
 
 	<properties>
-		<project.version>CHRONOS-5.3.0</project.version>
+		<project.version>CHRONOS-5.4.0</project.version>
 	</properties>
 
 	<groupId>io.github.chronos-labs</groupId>

--- a/xchange-kucoin/pom.xml
+++ b/xchange-kucoin/pom.xml
@@ -9,7 +9,7 @@
 	</parent>
 
 	<properties>
-		<project.version>CHRONOS-5.4.0-local</project.version>
+		<project.version>CHRONOS-5.4.0</project.version>
 	</properties>
 
 	<groupId>io.github.chronos-labs</groupId>

--- a/xchange-kucoin/src/main/java/org/knowm/xchange/kucoin/KucoinBaseService.java
+++ b/xchange-kucoin/src/main/java/org/knowm/xchange/kucoin/KucoinBaseService.java
@@ -16,6 +16,7 @@ import org.knowm.xchange.kucoin.service.KucoinDigest;
 import org.knowm.xchange.kucoin.service.LimitOrderAPI;
 import org.knowm.xchange.kucoin.service.OrderAPI;
 import org.knowm.xchange.kucoin.service.OrderBookAPI;
+import org.knowm.xchange.kucoin.service.OrderCancelByClientOrderIdAPI;
 import org.knowm.xchange.kucoin.service.SymbolAPI;
 import org.knowm.xchange.kucoin.service.TradingFeeAPI;
 import org.knowm.xchange.kucoin.service.WebsocketAPI;
@@ -33,6 +34,7 @@ public class KucoinBaseService extends BaseResilientExchangeService<KucoinExchan
   protected final WithdrawalAPI withdrawalAPI;
   protected final DepositAPI depositAPI;
   protected final OrderAPI orderApi;
+  protected final OrderCancelByClientOrderIdAPI orderCancelByClientOrderIdAPI;
   protected final LimitOrderAPI limitOrderAPI;
   protected final FillAPI fillApi;
   protected final HistOrdersAPI histOrdersApi;
@@ -55,6 +57,7 @@ public class KucoinBaseService extends BaseResilientExchangeService<KucoinExchan
     this.withdrawalAPI = service(exchange, WithdrawalAPI.class);
     this.depositAPI = service(exchange, DepositAPI.class);
     this.orderApi = service(exchange, OrderAPI.class);
+    this.orderCancelByClientOrderIdAPI = service(exchange, OrderCancelByClientOrderIdAPI.class);
     this.limitOrderAPI = service(exchange, LimitOrderAPI.class);
     this.fillApi = service(exchange, FillAPI.class);
     this.histOrdersApi = service(exchange, HistOrdersAPI.class);

--- a/xchange-kucoin/src/main/java/org/knowm/xchange/kucoin/KucoinTradeService.java
+++ b/xchange-kucoin/src/main/java/org/knowm/xchange/kucoin/KucoinTradeService.java
@@ -25,10 +25,12 @@ import org.knowm.xchange.dto.trade.UserTrades;
 import org.knowm.xchange.exceptions.NotAvailableFromExchangeException;
 import org.knowm.xchange.instrument.Instrument;
 import org.knowm.xchange.kucoin.dto.response.HistOrdersResponse;
+import org.knowm.xchange.kucoin.dto.response.OrderCancelByClientOrderIdResponse;
 import org.knowm.xchange.kucoin.dto.response.OrderCancelResponse;
 import org.knowm.xchange.kucoin.dto.response.OrderResponse;
 import org.knowm.xchange.kucoin.dto.response.Pagination;
 import org.knowm.xchange.kucoin.dto.response.TradeResponse;
+import org.knowm.xchange.kucoin.service.OrderCancelByClientOrderIdAPI;
 import org.knowm.xchange.service.trade.TradeService;
 import org.knowm.xchange.service.trade.params.CancelAllOrders;
 import org.knowm.xchange.service.trade.params.CancelOrderByCurrencyPair;
@@ -206,6 +208,15 @@ public class KucoinTradeService extends KucoinTradeServiceRaw implements TradeSe
   public boolean cancelOrder(String orderId) throws IOException {
     OrderCancelResponse response = kucoinCancelOrder(orderId);
     return response.getCancelledOrderIds().contains(orderId);
+  }
+
+  /*
+   * Kucion has a seperate endpoint for cancelling by client order id
+   * for some absurd reason: https://www.kucoin.com/docs/rest/spot-trading/orders/cancel-order-by-clientoid.
+   */
+  public boolean cancelOrderByClientOrderId(String clientOrderId) throws IOException {
+    OrderCancelByClientOrderIdResponse response = kucoinCancelOrderByClientOrderId(clientOrderId);
+    return response.getClientOid().equals(clientOrderId);
   }
 
   @Override

--- a/xchange-kucoin/src/main/java/org/knowm/xchange/kucoin/KucoinTradeServiceRaw.java
+++ b/xchange-kucoin/src/main/java/org/knowm/xchange/kucoin/KucoinTradeServiceRaw.java
@@ -9,6 +9,7 @@ import java.util.List;
 import org.knowm.xchange.client.ResilienceRegistries;
 import org.knowm.xchange.kucoin.dto.request.OrderCreateApiRequest;
 import org.knowm.xchange.kucoin.dto.response.HistOrdersResponse;
+import org.knowm.xchange.kucoin.dto.response.OrderCancelByClientOrderIdResponse;
 import org.knowm.xchange.kucoin.dto.response.OrderCancelResponse;
 import org.knowm.xchange.kucoin.dto.response.OrderCreateResponse;
 import org.knowm.xchange.kucoin.dto.response.OrderResponse;
@@ -156,6 +157,24 @@ public class KucoinTradeServiceRaw extends KucoinBaseService {
                     passphrase,
                     apiKeyVersion,
                     orderId))
+            .withRetry(retry("kucoinCancelOrder"))
+            .withRateLimiter(rateLimiter(PRIVATE_REST_ENDPOINT_RATE_LIMITER))
+            .call()
+    );
+  }
+
+  public OrderCancelByClientOrderIdResponse kucoinCancelOrderByClientOrderId(String clientOrderId) throws IOException {
+    checkAuthenticated();
+    return classifyingExceptions(
+        () -> decorateApiCall(
+            () ->
+                orderCancelByClientOrderIdAPI.cancelOrderByClientOrderId(
+                    apiKey,
+                    digest,
+                    nonceFactory,
+                    passphrase,
+                    apiKeyVersion,
+                    clientOrderId))
             .withRetry(retry("kucoinCancelOrder"))
             .withRateLimiter(rateLimiter(PRIVATE_REST_ENDPOINT_RATE_LIMITER))
             .call()

--- a/xchange-kucoin/src/main/java/org/knowm/xchange/kucoin/dto/response/OrderCancelByClientOrderIdResponse.java
+++ b/xchange-kucoin/src/main/java/org/knowm/xchange/kucoin/dto/response/OrderCancelByClientOrderIdResponse.java
@@ -1,0 +1,19 @@
+package org.knowm.xchange.kucoin.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import java.util.HashSet;
+import java.util.Set;
+import lombok.Data;
+import lombok.ToString;
+
+
+/*
+ * https://www.kucoin.com/docs/rest/spot-trading/orders/cancel-order-by-clientoid
+ */
+@Data
+@ToString
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class OrderCancelByClientOrderIdResponse {
+  private String cancelledOrderId;
+  private String clientOid;
+}

--- a/xchange-kucoin/src/main/java/org/knowm/xchange/kucoin/service/OrderCancelByClientOrderIdAPI.java
+++ b/xchange-kucoin/src/main/java/org/knowm/xchange/kucoin/service/OrderCancelByClientOrderIdAPI.java
@@ -1,0 +1,43 @@
+package org.knowm.xchange.kucoin.service;
+
+import java.io.IOException;
+
+import javax.ws.rs.DELETE;
+import javax.ws.rs.HeaderParam;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+import org.knowm.xchange.kucoin.dto.KucoinException;
+import org.knowm.xchange.kucoin.dto.response.KucoinResponse;
+import org.knowm.xchange.kucoin.dto.response.OrderCancelByClientOrderIdResponse;
+import org.knowm.xchange.kucoin.dto.response.OrderCancelResponse;
+
+import si.mazi.rescu.ParamsDigest;
+import si.mazi.rescu.SynchronizedValueFactory;
+
+
+@Path("/api/v1/order/client-order")
+@Produces(MediaType.APPLICATION_JSON)
+public interface OrderCancelByClientOrderIdAPI {
+
+      /**
+   * Cancel an order
+   *
+   * <p>Cancel a previously placed order.
+   *
+   * @param orderId The order id.
+   * @return A response containing the id of the cancelled order.
+   */
+  @DELETE
+  @Path("/{clientOid}")
+  KucoinResponse<OrderCancelByClientOrderIdResponse> cancelOrderByClientOrderId(
+      @HeaderParam(APIConstants.API_HEADER_KEY) String apiKey,
+      @HeaderParam(APIConstants.API_HEADER_SIGN) ParamsDigest signature,
+      @HeaderParam(APIConstants.API_HEADER_TIMESTAMP) SynchronizedValueFactory<Long> nonce,
+      @HeaderParam(APIConstants.API_HEADER_PASSPHRASE) String apiPassphrase,
+      @HeaderParam(APIConstants.API_HEADER_KEY_VERSION) String apiKeyVersion,
+      @PathParam("clientOid") String orderId)
+      throws IOException, KucoinException;
+}

--- a/xchange-stream-kucoin/pom.xml
+++ b/xchange-stream-kucoin/pom.xml
@@ -10,7 +10,7 @@
     </parent>
 
     <properties>
-        <project.version>CHRONOS-5.3.0</project.version>
+        <project.version>CHRONOS-5.4.0</project.version>
     </properties>
 
     <name>XChange Kucoin Stream</name>
@@ -42,7 +42,7 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.18.24</version>
+            <version>1.18.30</version>
             <scope>provided</scope>
         </dependency>
 


### PR DESCRIPTION
For Kucoin, cancel by client order is a seperate endpoint: https://www.kucoin.com/docs/rest/spot-trading/orders/cancel-order-by-clientoid and is not a parameter in the standard cancel order endpoint.

This required adding support for a new endpoint to the XChange SDK.